### PR TITLE
Remove references to pg_class.reltoastidxid

### DIFF
--- a/gatherer/src/main/java/de/zalando/pgobserver/gatherer/TableStatsGatherer.java
+++ b/gatherer/src/main/java/de/zalando/pgobserver/gatherer/TableStatsGatherer.java
@@ -144,14 +144,14 @@ public class TableStatsGatherer extends ADBGatherer {
         
         if (useApproximation)
              sql = "SELECT ut.schemaname, ut.relname, "
-                          + "(c.relpages + coalesce(ctd.relpages,0) + coalesce(cti.relpages, 0))::int8 * 8192 as table_size,"
-                          + "(select coalesce(sum(relpages),0) from pg_class ci join pg_index on indexrelid =  ci.oid where indrelid = c.oid)::int8 * 8192 as index_size,"
+                          + "(c.relpages + coalesce(ctd.relpages,0) + "
+                          + "  (select coalesce(sum(ci.relpages),0) from pg_class ci join pg_index on indexrelid = ci.oid where indrelid = ctd.oid))::int8 * 8192 as table_size,"
+                          + "(select coalesce(sum(ci.relpages),0) from pg_class ci join pg_index on indexrelid =  ci.oid where indrelid = c.oid)::int8 * 8192 as index_size,"
                           + "seq_scan, seq_tup_read, idx_scan,"
                           + "idx_tup_fetch, n_tup_ins , n_tup_upd , n_tup_del , n_tup_hot_upd"
                      + " FROM pg_stat_user_tables ut"
                      + " JOIN pg_class c ON c.oid = ut.relid"
-                     + " LEFT JOIN pg_class ctd ON ctd.oid = c.reltoastrelid"
-                     + " LEFT JOIN pg_class cti ON cti.oid = ctd.reltoastidxid;";            
+                     + " LEFT JOIN pg_class ctd ON ctd.oid = c.reltoastrelid;";
         else
             sql = "SELECT schemaname, relname, pg_table_size(relid) as table_size,"
                           + "pg_indexes_size(relid) as index_size, seq_scan, seq_tup_read, idx_scan,"


### PR DESCRIPTION
This field is now dropped in 9.4, because there could be multiple
indexes per TOAST table.  We join pg_indexes with pg_class to estimate
table size instead, this works on earlier versions as well.