### PR TITLE
Fixed incorrect maven version detection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ echo "                                                                          
 progress 'Checking prerequisites'
 git --version > /dev/null || fail "git is required"
 
-MAVEN_VERSION=$(mvn --version | head -n 1 | grep -o '3\.')
+MAVEN_VERSION=$(mvn --version | head -n 1 | grep -o '3\.' | head -c 2)
 [ "v$MAVEN_VERSION" = "v3." ] || fail "Maven 3 is required"
 
 JAVA_VERSION=$(java -version 2>&1 | head -n 1 | grep -o '1\.[78]')


### PR DESCRIPTION
Fixed incorrect maven version detection for maven that has version number with multiple 3s

Reported as well in #59

E.g. `Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T17:41:47+01:00)`
