### PR TITLE
Choose specified password when connecting

### DIFF
--- a/frontend/src/web.py
+++ b/frontend/src/web.py
@@ -69,7 +69,7 @@ def main():
     settings['database']['port'] = (os.getenv('PGOBS_PORT') or settings['database'].get('port') or 5432)
     settings['database']['name'] = (os.getenv('PGOBS_DATABASE') or settings['database'].get('name'))
     settings['database']['frontend_user'] = (os.getenv('PGOBS_USER') or settings['database'].get('frontend_user'))
-    settings['database']['password'] = (os.getenv('PGOBS_PASSWORD') or settings['database'].get('frontend_password'))
+    settings['database']['frontend_password'] = (os.getenv('PGOBS_PASSWORD') or settings['database'].get('frontend_password'))
 
     if not (settings['database'].get('host') and settings['database'].get('name') and settings['database'].get('frontend_user')):
         print 'Mandatory datastore connect details missing!'
@@ -86,7 +86,7 @@ def main():
     ))
     print 'Setting connection string to ... ' + conn_string
     # finished print conn_string to the world, password can be added
-    conn_string = conn_string + ' password=' + settings['database']['password']
+    conn_string = conn_string + ' password=' + settings['database']['frontend_password']
 
     datadb.setConnectionString(conn_string)
 

--- a/frontend/src/web.py
+++ b/frontend/src/web.py
@@ -86,7 +86,7 @@ def main():
     ))
     print 'Setting connection string to ... ' + conn_string
     # finished print conn_string to the world, password can be added
-    conn_string = conn_string + ' password=' + settings['database']['frontend_password']
+    conn_string = conn_string + ' password=' + settings['database']['password']
 
     datadb.setConnectionString(conn_string)
 


### PR DESCRIPTION
When specifying the password using the PGOBS_PASSWORD environment variable,
the frontend refuses to start:

```
KeyError: 'frontend_password'
```
