### PR TITLE
Upgrade guava version

### DIFF
--- a/gatherer/pom.xml
+++ b/gatherer/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>19.0</version>
+          <version>24.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>de.zalando</groupId>


### PR DESCRIPTION
This will resolve a moderate CVE.  Unfortunately the version for jackson is not
yet released.